### PR TITLE
Added cloudspanner.channels flag for GRPC channels

### DIFF
--- a/perfkitbenchmarker/linux_benchmarks/cloud_spanner_ycsb_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/cloud_spanner_ycsb_benchmark.py
@@ -81,6 +81,10 @@ flags.DEFINE_integer('cloud_spanner_ycsb_boundedstaleness',
                      0,
                      'The Cloud Spanner bounded staleness used in the YCSB '
                      'benchmark.')
+flags.DEFINE_integer('cloud_spanner_ycsb_channels',
+                     100,
+                     'The Cloud Spanner GRPC client channels used in the YCSB '
+                     'benchmark.')
 flags.DEFINE_string('cloud_spanner_ycsb_custom_release',
                     None,
                     'If provided, the URL of a custom YCSB release')
@@ -168,6 +172,7 @@ def Run(benchmark_spec):
       'cloudspanner.readmode': FLAGS.cloud_spanner_ycsb_readmode,
       'cloudspanner.boundedstaleness':
           FLAGS.cloud_spanner_ycsb_boundedstaleness,
+      'cloudspanner.channels': FLAGS.cloud_spanner_ycsb_channels,
       'cloudspanner.batchinserts': FLAGS.cloud_spanner_ycsb_batchinserts,
       'cloudspanner.host': benchmark_spec.spanner_instance.GetEndPoint(),
   }


### PR DESCRIPTION
The default channel count is set to 4 in the Spanner Java client library. For benchmarking a higher channel count is recommended, setting it here to 100 by default and adding the capability to change it via a runtime flag.